### PR TITLE
Patching up ExodusDatabase type so that the new Initialization type i…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Exodus"
 uuid = "f57ae99e-f805-4780-bdca-96e224be1e5a"
 authors = ["cmhamel <cmhamel32@gmail.com>"]
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"

--- a/src/ExodusTypes.jl
+++ b/src/ExodusTypes.jl
@@ -180,11 +180,12 @@ abstract type AbstractExodusSet{I, A} <: AbstractExodusType end
 abstract type AbstractExodusVariable <: AbstractExodusType end
 
 
-struct ExodusDatabase{M, I, B, F}
+struct ExodusDatabase{M, I, B, F, Init}
   exo::Cint
   mode::String
   file_name::String
-  init::Initialization
+  # init::Initialization
+  init::Init
   # name to id dict for reducing allocations from access by name
   block_name_dict::Dict{String, I}
   nset_name_dict::Dict{String, I}
@@ -288,7 +289,7 @@ function ExodusDatabase{M, I, B, F}(
   
   # get init
   init = Initialization(exo, B)
-  exo_db = ExodusDatabase{M, I, B, F}(
+  exo_db = ExodusDatabase{M, I, B, F, typeof(init)}(
     exo, mode, file_name, init,
     Dict{String, I}(), Dict{String, I}(), Dict{String, I}(), 
     Dict{String, I}(), Dict{String, I}(), Dict{String, I}(), Dict{String, I}(), Dict{String, I}()
@@ -487,7 +488,7 @@ function ExodusDatabase{M, I, B, F}(
 
   write_initialization!(exo, init)
 
-  return ExodusDatabase{M, I, B, F}(
+  return ExodusDatabase{M, I, B, F, typeof(init)}(
     exo, mode, file_name, init,
     Dict{String, I}(), Dict{String, I}(), Dict{String, I}(), 
     Dict{String, I}(), Dict{String, I}(), Dict{String, I}(), Dict{String, I}(), Dict{String, I}()
@@ -583,6 +584,8 @@ get_file_id(exo::ExodusDatabase)   = getfield(exo, :exo)
 
 # helper method
 Initialization(exo::ExodusDatabase{M, I, B, F}) where {M, I, B, F} = Initialization(exo.exo, B)
+
+initialization(exo::ExodusDatabase) = exo.init
 
 """
 """

--- a/test/TestIO.jl
+++ b/test/TestIO.jl
@@ -1,6 +1,6 @@
 @exodus_unit_test_set "Test ExodusDatabase Read Mode" begin
   exo = ExodusDatabase("./example_output/output.gold", "r")
-  @test typeof(exo) == ExodusDatabase{Int32, Int32, Int32, Float64}
+  # @test typeof(exo) == ExodusDatabase{Int32, Int32, Int32, Float64}
   @test Exodus.get_map_int_type(exo) == Int32
   @test Exodus.get_id_int_type(exo) == Int32
   @test Exodus.get_bulk_int_type(exo) == Int32
@@ -11,7 +11,7 @@ end
 @exodus_unit_test_set "Test ExodusDatabase Write Mode - Defaults" begin
   # exo = ExodusDatabase("./test_write.e")
   exo = ExodusDatabase("./test_write.e", "w")
-  @test typeof(exo) == ExodusDatabase{Int32, Int32, Int32, Float64}
+  # @test typeof(exo) == ExodusDatabase{Int32, Int32, Int32, Float64}
   @test Exodus.get_map_int_type(exo) == Int32
   @test Exodus.get_id_int_type(exo) == Int32
   @test Exodus.get_bulk_int_type(exo) == Int32
@@ -34,7 +34,7 @@ end
     "./test_write_meaningful.e", "w", init, 
     Int32, Int32, Int32, Float64
   )
-  @test typeof(exo) == ExodusDatabase{Int32, Int32, Int32, Float64}
+  # @test typeof(exo) == ExodusDatabase{Int32, Int32, Int32, Float64}
   @test Exodus.get_map_int_type(exo) == Int32
   @test Exodus.get_id_int_type(exo) == Int32
   @test Exodus.get_bulk_int_type(exo) == Int32
@@ -59,7 +59,7 @@ end
     "./test_write_meaningful.e", "w", init,
     Int32, Int32, Int32, Float64
   )
-  @test typeof(exo) == ExodusDatabase{Int32, Int32, Int32, Float64}
+  # @test typeof(exo) == ExodusDatabase{Int32, Int32, Int32, Float64}
   @test Exodus.get_map_int_type(exo) == Int32
   @test Exodus.get_id_int_type(exo) == Int32
   @test Exodus.get_bulk_int_type(exo) == Int32
@@ -115,8 +115,11 @@ end
             B(Exodus.num_side_sets(init_old))
           }()
           exo = ExodusDatabase("./dummy_$(M)_$(I)_$(B)_$(F).e", "w", init, M, I, B, F)
-          @test typeof(exo) == ExodusDatabase{M, I, B, F}
-
+          # @test typeof(exo) == ExodusDatabase{M, I, B, F}
+          @test Exodus.get_map_int_type(exo) == M
+          @test Exodus.get_id_int_type(exo) == I
+          @test Exodus.get_bulk_int_type(exo) == B
+          @test Exodus.get_float_type(exo) == F
           close(exo)
 
           Base.Filesystem.rm("./dummy_$(M)_$(I)_$(B)_$(F).e")


### PR DESCRIPTION
…s properly typed. This was leading to type instabilities downstream. This still isn't quite type-stable on reading a file, but I'm not sure if it ever really can be.

Maybe eventually just ditch the initialization struct all together and make this typed parameters in the ExodusDatabase struct itself.