### PR TITLE
updating error handling to close the exodus file in case an error is …

### DIFF
--- a/src/Blocks.jl
+++ b/src/Blocks.jl
@@ -8,7 +8,7 @@ function read_block_id_map(exo::ExodusDatabase, block_id::I) where I <: Integer
   error_code = @ccall libexodus.ex_get_block_id_map(
     get_file_id(exo)::Cint, EX_ELEM_BLOCK::ex_entity_type, block_id::ex_entity_id, block_id_map::Ptr{void_int}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_element_block_id_map -> libexodus.ex_get_block_id_map")
+  exodus_error_check(exo, error_code, "Exodus.read_element_block_id_map -> libexodus.ex_get_block_id_map")
   return block_id_map
 end
 
@@ -29,7 +29,7 @@ function read_block_parameters(exo::ExodusDatabase{M, I, B, F}, block_id::Intege
     num_elem::Ptr{B}, num_nodes::Ptr{B}, num_edges::Ptr{B},
     num_faces::Ptr{B}, num_attributes::Ptr{B}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_element_block_parameters -> libexodus.ex_get_block")
+  exodus_error_check(exo, error_code, "Exodus.read_element_block_parameters -> libexodus.ex_get_block")
   element_type_out = unsafe_string(pointer(element_type))
   return element_type_out, num_elem[], num_nodes[], num_edges[], num_faces[], num_attributes[]
 end
@@ -42,7 +42,7 @@ function read_block_connectivity(exo::ExodusDatabase{M, I, B, F}, block_id::Inte
     get_file_id(exo)::Cint, EX_ELEM_BLOCK::ex_entity_type, block_id::ex_entity_id,
     conn::Ptr{B}, C_NULL::Ptr{Cvoid}, C_NULL::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_element_block_connectivity -> libexodus.ex_get_conn")
+  exodus_error_check(exo, error_code, "Exodus.read_element_block_connectivity -> libexodus.ex_get_conn")
   return conn
 end
 
@@ -60,7 +60,7 @@ function write_block_connectivity(exo::ExodusDatabase, block_id::Integer, conn::
     get_file_id(exo)::Cint, EX_ELEM_BLOCK::ex_entity_type, block_id::ex_entity_id,
     conn::Ptr{void_int}, conn_face::Ptr{void_int}, conn_edge::Ptr{void_int} 
   )::Cint
-  exodus_error_check(error_code, "Exodus_write_block_connectivity -> libexodus.ex_put_conn")
+  exodus_error_check(exo, error_code, "Exodus_write_block_connectivity -> libexodus.ex_put_conn")
 end
 
 """
@@ -76,7 +76,7 @@ function read_partial_block_connectivity(exo::ExodusDatabase, block_id::I, start
     start_num::Clonglong, num_ent::Clonglong,
     conn::Ptr{void_int}, conn_face::Ptr{void_int}, conn_edge::Ptr{void_int}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_partial_element_block_connectivity -> libexodus.ex_get_partial_conn")
+  exodus_error_check(exo, error_code, "Exodus.read_partial_element_block_connectivity -> libexodus.ex_get_partial_conn")
   return conn
 end
 
@@ -87,7 +87,7 @@ function read_element_type(exo::ExodusDatabase, block_id::I) where I <: Integer
   error_code = @ccall libexodus.ex_get_elem_type(
     get_file_id(exo)::Cint, block_id::ex_entity_id, element_type::Ptr{UInt8}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_element_type -> libexodus.ex_get_elem_type")
+  exodus_error_check(exo, error_code, "Exodus.read_element_type -> libexodus.ex_get_elem_type")
   return unsafe_string(pointer(element_type))
 end
 
@@ -139,7 +139,7 @@ function write_block(exo::ExodusDatabase, block::Block)
     block.num_elem::Clonglong, block.num_nodes_per_elem::Clonglong,
     0::Clonglong, 0::Clonglong, 0::Clonglong
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_element_block -> libexodus.ex_put_block")
+  exodus_error_check(exo, error_code, "Exodus.write_element_block -> libexodus.ex_put_block")
   write_block_connectivity(exo, block.id, block.conn)
 end
 
@@ -152,7 +152,7 @@ function write_block(exo::ExodusDatabase, block_id::Integer, elem_type::String, 
     num_elem::Clonglong, num_nodes_per_elem::Clonglong,
     0::Clonglong, 0::Clonglong, 0::Clonglong
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_element_block -> libexodus.ex_put_block")
+  exodus_error_check(exo, error_code, "Exodus.write_element_block -> libexodus.ex_put_block")
   write_block_connectivity(exo, block_id, conn)
 end
 

--- a/src/Coordinates.jl
+++ b/src/Coordinates.jl
@@ -13,14 +13,14 @@ function read_coordinates(exo::ExodusDatabase)
     y_coords = C_NULL
     z_coords = C_NULL
     error_code = @ccall libexodus.ex_get_coord(exo.exo::Cint, x_coords::Ptr{Cvoid}, y_coords::Ptr{Cvoid}, z_coords::Ptr{Cvoid})::Cint
-    exodus_error_check(error_code, "Exodus.read_coordinates -> libexodus.ex_get_coord")
+    exodus_error_check(exo, error_code, "Exodus.read_coordinates -> libexodus.ex_get_coord")
     coords[1, :] = x_coords
   elseif num_dimensions(exo.init) == 2
     x_coords = Vector{float_type}(undef, n_nodes)
     y_coords = Vector{float_type}(undef, n_nodes)
     z_coords = C_NULL
     error_code = @ccall libexodus.ex_get_coord(exo.exo::Cint, x_coords::Ptr{Cvoid}, y_coords::Ptr{Cvoid}, z_coords::Ptr{Cvoid})::Cint
-    exodus_error_check(error_code, "Exodus.read_coordinates -> libexodus.ex_get_coord")
+    exodus_error_check(exo, error_code, "Exodus.read_coordinates -> libexodus.ex_get_coord")
     coords[1, :] = x_coords
     coords[2, :] = y_coords
   elseif num_dimensions(exo.init) == 3
@@ -28,7 +28,7 @@ function read_coordinates(exo::ExodusDatabase)
     y_coords = Vector{float_type}(undef, n_nodes)
     z_coords = Vector{float_type}(undef, n_nodes)
     error_code = @ccall libexodus.ex_get_coord(exo.exo::Cint, x_coords::Ptr{Cvoid}, y_coords::Ptr{Cvoid}, z_coords::Ptr{Cvoid})::Cint
-    exodus_error_check(error_code, "Exodus.read_coordinates -> libexodus.ex_get_coord")
+    exodus_error_check(exo, error_code, "Exodus.read_coordinates -> libexodus.ex_get_coord")
     coords[1, :] = x_coords
     coords[2, :] = y_coords
     coords[3, :] = z_coords
@@ -54,7 +54,7 @@ function read_partial_coordinates(exo::ExodusDatabase, start_node_num::I, n_node
       get_file_id(exo)::Cint, start_node_num::Clonglong, n_nodes::Clonglong,
       x_coords::Ptr{Cvoid}, y_coords::Ptr{Cvoid}, z_coords::Ptr{Cvoid}
     )::Cint
-    exodus_error_check(error_code, "Exodus.read_partial_coordinates -> libexodus.read_partial_coordinates")
+    exodus_error_check(exo, error_code, "Exodus.read_partial_coordinates -> libexodus.read_partial_coordinates")
     coords[1, :] = x_coords
   elseif num_dim == 2
     x_coords = Vector{float_type}(undef, n_nodes)
@@ -64,7 +64,7 @@ function read_partial_coordinates(exo::ExodusDatabase, start_node_num::I, n_node
       get_file_id(exo)::Cint, start_node_num::Clonglong, n_nodes::Clonglong,
       x_coords::Ptr{Cvoid}, y_coords::Ptr{Cvoid}, z_coords::Ptr{Cvoid}
     )::Cint
-    exodus_error_check(error_code, "Exodus.read_partial_coordinates -> libexodus.read_partial_coordinates")
+    exodus_error_check(exo, error_code, "Exodus.read_partial_coordinates -> libexodus.read_partial_coordinates")
     coords[1, :] = x_coords
     coords[2, :] = y_coords
   elseif num_dim == 3
@@ -75,7 +75,7 @@ function read_partial_coordinates(exo::ExodusDatabase, start_node_num::I, n_node
       get_file_id(exo)::Cint, start_node_num::Clonglong, n_nodes::Clonglong,
       x_coords::Ptr{Cvoid}, y_coords::Ptr{Cvoid}, z_coords::Ptr{Cvoid}
     )::Cint
-    exodus_error_check(error_code, "Exodus.read_partial_coordinates -> libexodus.read_partial_coordinates")
+    exodus_error_check(exo, error_code, "Exodus.read_partial_coordinates -> libexodus.read_partial_coordinates")
     coords[1, :] = x_coords
     coords[2, :] = y_coords
     coords[3, :] = z_coords
@@ -98,7 +98,7 @@ function read_partial_coordinates_component(exo::ExodusDatabase, start_node_num:
   error_code = @ccall libexodus.ex_get_partial_coord_component(
     get_file_id(exo)::Cint, start_node_num::Clonglong, n_nodes::Clonglong, component::Cint, coords::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_partial_coordinates_component -> libexodus.ex_get_partial_coord_component")
+  exodus_error_check(exo, error_code, "Exodus.read_partial_coordinates_component -> libexodus.ex_get_partial_coord_component")
   return coords
 end
 
@@ -124,7 +124,7 @@ function read_coordinate_names(exo::ExodusDatabase)
     coord_names[n] = Vector{UInt8}(undef, MAX_LINE_LENGTH)
   end
   error_code = @ccall libexodus.ex_get_coord_names(get_file_id(exo)::Cint, coord_names::Ptr{Ptr{UInt8}})::Cint
-  exodus_error_check(error_code, "Exodus.read_coordinate_names -> libexodus.ex_get_coord_names")
+  exodus_error_check(exo, error_code, "Exodus.read_coordinate_names -> libexodus.ex_get_coord_names")
   new_coord_names = Vector{String}(undef, num_dimensions(exo.init))
   for n in 1:num_dimensions(exo.init)
     new_coord_names[n] = unsafe_string(pointer(coord_names[n]))
@@ -170,7 +170,7 @@ function write_coordinates(exo::ExodusDatabase, coords::VecOrMat{F}) where {F <:
   error_code = @ccall libexodus.ex_put_coord(
     get_file_id(exo)::Cint, x_coords::Ptr{Cvoid}, y_coords::Ptr{Cvoid}, z_coords::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_coordinates -> libexodus.ex_put_coord")
+  exodus_error_check(exo, error_code, "Exodus.write_coordinates -> libexodus.ex_put_coord")
 end
 
 """
@@ -182,7 +182,7 @@ function write_coordinate_names(exo::ExodusDatabase, coord_names::Vector{String}
     new_coord_names[n] = Vector{UInt8}(coord_name)
   end
   error_code = @ccall libexodus.ex_put_coord_names(get_file_id(exo)::Cint, new_coord_names::Ptr{Ptr{UInt8}})::Cint
-  exodus_error_check(error_code, "Exodus.write_coordinate_names -> libexodus.ex_put_coord_names")
+  exodus_error_check(exo, error_code, "Exodus.write_coordinate_names -> libexodus.ex_put_coord_names")
 end
 
 """
@@ -209,7 +209,7 @@ function write_partial_coordinates(exo::ExodusDatabase, start_node_num::I, coord
     get_file_id(exo)::Cint, start_node_num::Clonglong, n_nodes::Clonglong,
     x_coords::Ptr{Cvoid}, y_coords::Ptr{Cvoid}, z_coords::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_partial_coordinates -> libexodus.ex_put_partial_coord")
+  exodus_error_check(exo, error_code, "Exodus.write_partial_coordinates -> libexodus.ex_put_partial_coord")
 end
 
 """
@@ -220,7 +220,7 @@ function write_partial_coordinates_component(exo::ExodusDatabase, start_node_num
     get_file_id(exo)::Cint, start_node_num::Clonglong, length(coords)::Clonglong, component::Cint,
     coords::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_partial_coordinates_component -> libexodus.ex_put_partial_coord_component")
+  exodus_error_check(exo, error_code, "Exodus.write_partial_coordinates_component -> libexodus.ex_put_partial_coord_component")
 end
 
 """

--- a/src/Errors.jl
+++ b/src/Errors.jl
@@ -10,14 +10,21 @@ end
 Base.show(io::IO, e::ExodusError) = 
 println(io, "Error from exodusII library in method $(e.error_msg) with code $(e.error_code)")
 
+function exodus_error_check(error_code::T, method_name::String) where {T <: Integer}
+  if error_code < 0
+    throw(ExodusError(error_code, method_name))
+  end
+end
+
 """
 Generic error handling method.
 # Arguments
 - `error_code::T`: error code, usually negative means something went bad
 - `method_name::String`: method name that called this
 """
-function exodus_error_check(error_code::T, method_name::String) where {T <: Integer}
+function exodus_error_check(exo::Cint, error_code::T, method_name::String) where {T <: Integer}
   if error_code < 0
+    error_code = @ccall libexodus.ex_close(exo::Cint)::Cint
     throw(ExodusError(error_code, method_name))
   end
 end

--- a/src/Info.jl
+++ b/src/Info.jl
@@ -11,7 +11,7 @@ function read_info(exo::ExodusDatabase)
   error_code = @ccall libexodus.ex_get_info(
     get_file_id(exo)::Cint, info::Ptr{Ptr{UInt8}}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_info -> libexodus.ex_get_info")
+  exodus_error_check(exo, error_code, "Exodus.read_info -> libexodus.ex_get_info")
   new_info = Vector{String}(undef, num_info)
   for n in eachindex(info)
     new_info[n] = unsafe_string(pointer(info[n]))
@@ -25,5 +25,5 @@ function write_info(exo::ExodusDatabase, info::Vector{String})
   error_code = @ccall libexodus.ex_put_info(
     get_file_id(exo)::Cint, length(info)::Cint, info::Ptr{Ptr{UInt8}}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_info -> libexodus.ex_put_info")
+  exodus_error_check(exo, error_code, "Exodus.write_info -> libexodus.ex_put_info")
 end

--- a/src/Maps.jl
+++ b/src/Maps.jl
@@ -4,7 +4,7 @@ TODO change to not use void_int
 function read_map(exo::ExodusDatabase{M, I, B, F}) where {M, I, B, F}
   elem_map = Vector{M}(undef, num_elements(exo.init))
   error_code = @ccall libexodus.ex_get_map(get_file_id(exo)::Cint, elem_map::Ptr{void_int})::Cint
-  exodus_error_check(error_code, "Exodus.read_element_map -> libexodus.ex_get_map")
+  exodus_error_check(exo, error_code, "Exodus.read_element_map -> libexodus.ex_get_map")
   return elem_map
 end
 
@@ -25,7 +25,7 @@ function read_id_map(
   error = @ccall libexodus.ex_get_id_map(
     exo.exo::Cint, entity_type(type)::ex_entity_type, map::Ptr{M}
   )::Cint
-  exodus_error_check(error, "read_id_map -> ex_get_id_map")
+  exodus_error_check(exo, error, "read_id_map -> ex_get_id_map")
 
   return map
 end
@@ -45,7 +45,7 @@ function write_id_map(
   error = @ccall libexodus.ex_put_id_map(
     exo.exo::Cint, entity_type(type)::ex_entity_type, map::Ptr{M}
   )::Cint
-  exodus_error_check(error, "write_id_map -> ex_put_id_map")
+  exodus_error_check(exo, error, "write_id_map -> ex_put_id_map")
 end
 
 # TODO implement this, it might be useful

--- a/src/ParallelExodus.jl
+++ b/src/ParallelExodus.jl
@@ -7,7 +7,7 @@ function read_init_info(exo::ExodusDatabase)
   error_code = @ccall libexodus.ex_get_init_info(
     get_file_id(exo)::Cint, num_proc::Ptr{Cint}, num_proc_in_f::Ptr{Cint}, ftype::Ptr{UInt8}
   )::Cint
-  exodus_error_check(error_code, "Exodus.ParallelExodusDatabase -> libexodus.ex_get_init_info")
+  exodus_error_check(exo, error_code, "Exodus.ParallelExodusDatabase -> libexodus.ex_get_init_info")
   return num_proc[], num_proc_in_f[], unsafe_string(pointer(ftype))
 end
 
@@ -23,7 +23,7 @@ function InitializationGlobal(exo::ExodusDatabase{M, I, B, F, Init}) where {M, I
     get_file_id(exo)::Cint, num_nodes::Ptr{Cint}, num_elem::Ptr{Cint},
     num_elem_blk::Ptr{Cint}, num_node_sets::Ptr{Cint}, num_side_sets::Ptr{Cint}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_init_global -> libexodus.ex_get_init_global")
+  exodus_error_check(exo, error_code, "Exodus.read_init_global -> libexodus.ex_get_init_global")
   return Initialization{
     num_dimensions(exo.init), num_nodes[], num_elem[],
     num_elem_blk[], num_node_sets[], num_side_sets[]
@@ -75,7 +75,7 @@ function LoadBalanceParameters(exo::ExodusDatabase{M, I, B, F, Init}, processor:
     num_node_cmaps::Ptr{B}, num_elem_cmaps::Ptr{B},
     processor::Cint
   )::Cint
-  exodus_error_check(error_code, "Exodus.LoadBalanceParameters -> libexodus.ex_get_loadbal_param")
+  exodus_error_check(exo, error_code, "Exodus.LoadBalanceParameters -> libexodus.ex_get_loadbal_param")
   return LoadBalanceParameters{B}(
     num_int_nodes[], num_bor_nodes[], num_ext_nodes[],
     num_int_elems[], num_bor_elems[],
@@ -117,7 +117,7 @@ function CommunicationMapParameters(exo::ExodusDatabase{M, I, B, F, Init}, lb_pa
     elem_cmap_ids::Ptr{B}, elem_cmap_elem_cnts::Ptr{B},
     processor::Cint
   )::Cint
-  exodus_error_check(error_code, "Exodus.CommunicationMapParameters -> libexodus.ex_get_cmap_params")
+  exodus_error_check(exo, error_code, "Exodus.CommunicationMapParameters -> libexodus.ex_get_cmap_params")
   return CommunicationMapParameters{B}(
     node_cmap_ids .+ 1, node_cmap_node_cnts,
     elem_cmap_ids .+ 1, elem_cmap_elem_cnts
@@ -142,7 +142,7 @@ function NodeCommunicationMap(exo::ExodusDatabase{M, I, B, F, Init}, node_map_id
     node_ids::Ptr{B}, proc_ids::Ptr{B},
     processor::Cint
   )::Cint
-  exodus_error_check(error_code, "Exodus.NodeCommunicationMap -> libexodus.ex_get_node_cmap")
+  exodus_error_check(exo, error_code, "Exodus.NodeCommunicationMap -> libexodus.ex_get_node_cmap")
 
   return NodeCommunicationMap{B}(node_ids, proc_ids .+ 1) # note adding 1 to proc ids to make them julia indexed
 end
@@ -168,7 +168,7 @@ function ElementCommunicationMap(exo::ExodusDatabase{M, I, B, F, Init}, elem_map
     elem_ids::Ptr{B}, side_ids::Ptr{B}, proc_ids::Ptr{B},
     processor::Cint
   )::Cint
-  exodus_error_check(error_code, "Exodus.ElementCommunicationMap -> libexodus.ex_get_elem_cmap")
+  exodus_error_check(exo, error_code, "Exodus.ElementCommunicationMap -> libexodus.ex_get_elem_cmap")
   return ElementCommunicationMap{B}(elem_ids, side_ids, proc_ids .+ 1) # note adding 1 to proc ids to make them julia indexed
 end
 
@@ -194,7 +194,7 @@ function ProcessorNodeMaps(exo::ExodusDatabase{M, I, B, F, Init}, processor::Ity
     node_map_internal::Ptr{B}, node_map_border::Ptr{B}, node_map_external::Ptr{B},
     processor::Cint
   )::Cint
-  exodus_error_check(error_code, "Exodus.ProcessorNodeMap -> libexodus.ex_get_processor_node_maps")
+  exodus_error_check(exo, error_code, "Exodus.ProcessorNodeMap -> libexodus.ex_get_processor_node_maps")
   return ProcessorNodeMaps{B}(node_map_internal, node_map_border, node_map_external)
 end
 
@@ -218,6 +218,6 @@ function ProcessorElementMaps(exo::ExodusDatabase{M, I, B, F, Init}, processor::
     elem_map_internal::Ptr{B}, elem_map_border::Ptr{B},
     processor::Cint
   )::Cint
-  exodus_error_check(error_code, "Exodus.ProcessorElementMaps -> libexodus.ex_get_processor_elem_maps")
+  exodus_error_check(exo, error_code, "Exodus.ProcessorElementMaps -> libexodus.ex_get_processor_elem_maps")
   return ProcessorElementMaps{B}(elem_map_internal, elem_map_border)
 end

--- a/src/QA.jl
+++ b/src/QA.jl
@@ -13,7 +13,7 @@ function read_qa(exo::ExodusDatabase)
   error_code = @ccall libexodus.ex_get_qa(
     get_file_id(exo)::Cint, qa_record::Ptr{Ptr{UInt8}}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_qa -> libexodus.ex_get_qa")
+  exodus_error_check(exo, error_code, "Exodus.read_qa -> libexodus.ex_get_qa")
 
   new_qa_record = Matrix{String}(undef, num_qa_rec, 4)
   for i in 1:num_qa_rec
@@ -31,5 +31,5 @@ function write_qa(exo::ExodusDatabase, qa_record::Matrix{String})
   error_code = @ccall libexodus.ex_put_qa(
     get_file_id(exo)::Cint, num_qa_records::Cint, qa_record::Ptr{Ptr{UInt8}}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_qa -> libexodus.ex_put_qa")
+  exodus_error_check(exo, error_code, "Exodus.write_qa -> libexodus.ex_put_qa")
 end

--- a/src/Sets.jl
+++ b/src/Sets.jl
@@ -6,7 +6,7 @@ function read_ids(exo::ExodusDatabase{M, I, B, F}, ::Type{S}) where {M, I, B, F,
   error_code = @ccall libexodus.ex_get_ids(
     get_file_id(exo)::Cint, entity_type(S)::ex_entity_type, ids::Ptr{B}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_set_ids -> libexodus.ex_get_ids")
+  exodus_error_check(exo, error_code, "Exodus.read_set_ids -> libexodus.ex_get_ids")
   return ids
 end
 
@@ -18,7 +18,7 @@ function read_name(exo::ExodusDatabase, ::Type{S}, id::Integer) where S <: Abstr
     get_file_id(exo)::Cint, entity_type(S)::ex_entity_type, 
     id::ex_entity_id, name::Ptr{UInt8}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_name -> libexodus.ex_get_name")
+  exodus_error_check(exo, error_code, "Exodus.read_name -> libexodus.ex_get_name")
   return unsafe_string(pointer(name))
 end
 
@@ -47,7 +47,7 @@ function read_set_parameters(
     get_file_id(exo)::Cint, entity_type(S)::ex_entity_type, set_id::Clonglong, # set_id is really an ex_entity_id but that is weirdly causing a type instability
     num_entries::Ptr{I}, num_df::Ptr{I}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_set_parameters -> libexodus.ex_get_set_param")
+  exodus_error_check(exo, error_code, "Exodus.read_set_parameters -> libexodus.ex_get_set_param")
   return num_entries[], num_df[]
 end
 
@@ -61,7 +61,7 @@ function read_node_set_nodes(exo::ExodusDatabase{M, I, B, F}, set_id::Integer) w
     get_file_id(exo)::Cint, EX_NODE_SET::ex_entity_type, set_id::Clonglong, # set id is really a ex_entity_id but it's weirldy throwing a type instability
     entries::Ptr{B}, extras::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_node_set_nodes -> libexodus.ex_get_set")
+  exodus_error_check(exo, error_code, "Exodus.read_node_set_nodes -> libexodus.ex_get_set")
   return entries
 end
 
@@ -75,7 +75,7 @@ function read_side_set_elements_and_sides(exo::ExodusDatabase{M, I, B, F}, set_i
     get_file_id(exo)::Cint, EX_SIDE_SET::ex_entity_type, set_id::Clonglong, # set id is really a ex_entity_id but it's weirldy throwing a type instability
     entries::Ptr{B}, extras::Ptr{B}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_side_set_elements_and_sides -> libexodus.ex_get_set")
+  exodus_error_check(exo, error_code, "Exodus.read_side_set_elements_and_sides -> libexodus.ex_get_set")
   return entries, extras
 end
 
@@ -87,7 +87,7 @@ function read_side_set_node_list(exo::ExodusDatabase{M, I, B, F}, side_set_id::I
   error_code = @ccall libexodus.ex_get_side_set_node_list_len(
     get_file_id(exo)::Cint, side_set_id::Clonglong, side_set_node_list_len::Ptr{Cint} # side_set-Id should really be ex_entity_id but it's weirdly causing a type instability
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_side_set_node_list -> libexodus.ex_get_side_set_node_list_len")
+  exodus_error_check(exo, error_code, "Exodus.read_side_set_node_list -> libexodus.ex_get_side_set_node_list_len")
   
   num_sides, _ = read_set_parameters(exo, side_set_id, SideSet)
   side_set_node_cnt_list = Vector{B}(undef, num_sides)
@@ -97,7 +97,7 @@ function read_side_set_node_list(exo::ExodusDatabase{M, I, B, F}, side_set_id::I
     get_file_id(exo)::Cint, side_set_id::Clonglong, # should really be ex_entity_id but it's weirdly causing a type instability
     side_set_node_cnt_list::Ptr{B}, side_set_node_list::Ptr{B}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_side_set_node_list -> libexodus.ex_get_side_set_node_list")
+  exodus_error_check(exo, error_code, "Exodus.read_side_set_node_list -> libexodus.ex_get_side_set_node_list")
   return side_set_node_cnt_list, side_set_node_list
 end
 
@@ -149,7 +149,7 @@ function write_set_parameters(exo::ExodusDatabase{M, I, B, F}, set::T) where {M,
     get_file_id(exo)::Cint, entity_type(T)::ex_entity_type, set.id::Clonglong, # should be ex_entity_id
     length(set)::Clonglong, num_dist_fact_in_set::Clonglong
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_node_set_parameters -> libexodus.ex_put_set_param")
+  exodus_error_check(exo, error_code, "Exodus.write_node_set_parameters -> libexodus.ex_put_set_param")
 end
 
 """
@@ -162,7 +162,7 @@ function write_set(exo::ExodusDatabase{M, I, B, F}, set::T) where {T <: Abstract
     get_file_id(exo)::Cint, entity_type(T)::ex_entity_type, set.id::Clonglong, # should be ex_entity_id
     entries(set)::Ptr{B}, extras(set)::Ptr{Union{Cvoid, B}}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_set -> libexodus.ex_put_set")
+  exodus_error_check(exo, error_code, "Exodus.write_set -> libexodus.ex_put_set")
 end
 
 """
@@ -189,7 +189,7 @@ function write_name(exo::ExodusDatabase{M, I, B, F}, ::Type{S}, set_id::Integer,
     get_file_id(exo)::Cint, entity_type(S)::ex_entity_type, set_id::Clonglong, # should really be ex_entity_id
     name::Ptr{UInt8}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_set_name -> libexodus.ex_put_name")
+  exodus_error_check(exo, error_code, "Exodus.write_set_name -> libexodus.ex_put_name")
 end
 
 """
@@ -207,7 +207,7 @@ function write_name(exo::ExodusDatabase{M, I, B, F}, set::S, name::String) where
     get_file_id(exo)::Cint, entity_type(S)::ex_entity_type, set.id::Clonglong, # should really be ex_entity_id
     name::Ptr{UInt8}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_set_name -> libexodus.ex_put_name")
+  exodus_error_check(exo, error_code, "Exodus.write_set_name -> libexodus.ex_put_name")
 end
 
 """
@@ -217,5 +217,5 @@ function write_names(exo::ExodusDatabase, ::Type{S}, names::Vector{String}) wher
   error_code = @ccall libexodus.ex_put_names(
     get_file_id(exo)::Cint, entity_type(S)::ex_entity_type, names::Ptr{Ptr{UInt8}}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_set_names -> libexodus.ex_put_names")
+  exodus_error_check(exo, error_code, "Exodus.write_set_names -> libexodus.ex_put_names")
 end

--- a/src/Times.jl
+++ b/src/Times.jl
@@ -2,7 +2,7 @@
 """
 function read_number_of_time_steps(exo::ExodusDatabase)
   num_steps = @ccall libexodus.ex_inquire_int(get_file_id(exo)::Cint, EX_INQ_TIME::ex_inquiry)::UInt32
-  exodus_error_check(num_steps, "Exodus.ex_inquite_int -> libexodus.ex_inquire_int")
+  exodus_error_check(exo, num_steps, "Exodus.ex_inquite_int -> libexodus.ex_inquire_int")
   return num_steps
 end
 
@@ -14,7 +14,7 @@ function read_time(exo::ExodusDatabase, time_step::I) where I <: Integer
   error_code = @ccall libexodus.ex_get_time(
     get_file_id(exo)::Cint, time_step::Cint, time::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_time -> libexodus.ex_get_time")
+  exodus_error_check(exo, error_code, "Exodus.read_time -> libexodus.ex_get_time")
   return time[1]
 end
 
@@ -24,7 +24,7 @@ function read_times(exo::ExodusDatabase)
   num_steps = read_number_of_time_steps(exo)
   times = Vector{get_float_type(exo)}(undef, num_steps)
   error_code = @ccall libexodus.ex_get_all_times(get_file_id(exo)::Cint, times::Ptr{Cvoid})::Cint
-  exodus_error_check(error_code, "Exodus.read_times -> libexodus.read_times")
+  exodus_error_check(exo, error_code, "Exodus.read_times -> libexodus.read_times")
   return times
 end
 
@@ -32,5 +32,5 @@ end
 """
 function write_time(exo::ExodusDatabase, time_step::I, time_value::F) where {I <: Integer, F <: AbstractFloat}
   error_code = @ccall libexodus.ex_put_time(get_file_id(exo)::Cint, time_step::Cint, time_value::Ref{F})::Cint
-  exodus_error_check(error_code, "Exodus.write_time -> libexodus.ex_put_time")
+  exodus_error_check(exo, error_code, "Exodus.write_time -> libexodus.ex_put_time")
 end

--- a/src/Variables.jl
+++ b/src/Variables.jl
@@ -22,7 +22,7 @@ function read_number_of_variables(exo::ExodusDatabase, ::Type{V}) where V <: Abs
   error_code = @ccall libexodus.ex_get_variable_param(
     get_file_id(exo)::Cint, entity_type(V)::ex_entity_type, num_vars::Ptr{Cint}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_number_of_variables -> libexodus.ex_get_variable_param")
+  exodus_error_check(exo, error_code, "Exodus.read_number_of_variables -> libexodus.ex_get_variable_param")
   return num_vars[]
 end
 
@@ -53,7 +53,7 @@ function read_name(
   error_code = @ccall libexodus.ex_get_variable_name(
     get_file_id(exo)::Cint, entity_type(V)::ex_entity_type, var_index::Cint, var_name::Ptr{UInt8}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_variable_name -> libexodus.ex_get_variable_name")
+  exodus_error_check(exo, error_code, "Exodus.read_variable_name -> libexodus.ex_get_variable_name")
   return unsafe_string(pointer(var_name))
 end
 
@@ -177,7 +177,7 @@ function read_values(
     get_file_id(exo)::Cint, timestep::Cint, entity_type(V)::ex_entity_type,
     var_index::Cint, id::ex_entity_id, num_entries::Clonglong, values::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_values -> libexodus.ex_get_var")
+  exodus_error_check(exo, error_code, "Exodus.read_values -> libexodus.ex_get_var")
   return values
 end
 
@@ -205,7 +205,7 @@ function read_values(
     get_file_id(exo)::Cint, timestep::Cint, entity_type(V)::ex_entity_type,
     var_index::Cint, id::ex_entity_id, num_entries::Clonglong, values::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_values -> libexodus.ex_get_var")
+  exodus_error_check(exo, error_code, "Exodus.read_values -> libexodus.ex_get_var")
   return values
 end
 
@@ -233,7 +233,7 @@ function read_values(
     get_file_id(exo)::Cint, timestep::Cint, entity_type(V)::ex_entity_type,
     var_index::Cint, id::ex_entity_id, num_entries::Clonglong, values::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_values -> libexodus.ex_get_var")
+  exodus_error_check(exo, error_code, "Exodus.read_values -> libexodus.ex_get_var")
   return values
 end
 
@@ -261,7 +261,7 @@ function read_values(
     get_file_id(exo)::Cint, timestep::Cint, entity_type(V)::ex_entity_type,
     var_index::Cint, id::ex_entity_id, num_entries::Clonglong, values::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.read_values -> libexodus.ex_get_var")
+  exodus_error_check(exo, error_code, "Exodus.read_values -> libexodus.ex_get_var")
   return values
 end
 
@@ -363,7 +363,7 @@ function write_number_of_variables(exo::ExodusDatabase, ::Type{V}, num_vars::Int
   error_code = @ccall libexodus.ex_put_variable_param(
     get_file_id(exo)::Cint, entity_type(V)::ex_entity_type, num_vars::Cint
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_number_of_variables -> libexodus.ex_put_variable_param")
+  exodus_error_check(exo, error_code, "Exodus.write_number_of_variables -> libexodus.ex_put_variable_param")
 end
 
 """
@@ -377,7 +377,7 @@ function write_name(exo::ExodusDatabase, ::Type{V}, var_index::Integer, var_name
   error_code = @ccall libexodus.ex_put_variable_name(
     get_file_id(exo)::Cint, entity_type(V)::ex_entity_type, var_index::Cint, temp::Ptr{UInt8}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_variable_name -> libexodus.ex_put_variable_name")
+  exodus_error_check(exo, error_code, "Exodus.write_variable_name -> libexodus.ex_put_variable_name")
 end
 
 """
@@ -399,7 +399,7 @@ function write_names(exo::ExodusDatabase, type::Type{V}, var_names::Vector{Strin
     get_file_id(exo)::Cint, entity_type(V)::ex_entity_type, length(var_names)::Cint,
     var_names::Ptr{Ptr{UInt8}}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_variable_names -> libexodus.ex_put_variable_names")
+  exodus_error_check(exo, error_code, "Exodus.write_variable_names -> libexodus.ex_put_variable_names")
 end
 
 """
@@ -417,7 +417,7 @@ function write_values(
     var_index::Cint, id::ex_entity_id,
     num_nodes::Clonglong, var_values::Ptr{Cvoid}
   )::Cint
-  exodus_error_check(error_code, "Exodus.write_variable_values -> libexodus.ex_put_var")
+  exodus_error_check(exo, error_code, "Exodus.write_variable_values -> libexodus.ex_put_var")
 end
 
 """


### PR DESCRIPTION
…encountered. This is probably the best thing to do in most cases, although it may make some REPL usage annoying if a bad name is called for instance. Maybe some more fine-grained error handling should be considered in the future.